### PR TITLE
Add `fromFuture` and `accursedConversionToFuture` + More

### DIFF
--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -9,6 +9,9 @@ import scalaz.ioeffect.Errors._
 import scalaz.ioeffect.Errors.TerminatedException
 import scalaz.Liskov.<~<
 
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
+
 /**
  * An `IO[E, A]` ("Eye-Oh of Eeh Aye") is an immutable data structure that
  * describes an effectful action that may fail with an `E`, run forever, or
@@ -498,6 +501,12 @@ sealed abstract class IO[E, A] { self =>
   final def run[E2]: IO[E2, ExitResult[E, A]] = new IO.Run(self)
 
   /**
+   * Fold errors and values to some `B`, resuming with `IO[Void, B]`
+   */
+  final def fold[B](f: E => B, g: A => B): IO[Void, B] =
+    self.attempt[Void].map(_.fold(f, g))
+
+  /**
    * An integer that identifies the term in the `IO` sum type to which this
    * instance belongs (e.g. `IO.Tags.Point`).
    */
@@ -767,6 +776,24 @@ object IO extends IOInstances {
    */
   final def require[E, A](error: E): IO[E, Maybe[A]] => IO[E, A] =
     (io: IO[E, Maybe[A]]) => io.flatMap(_.cata(IO.now[E, A](_), IO.fail[E, A](error)))
+
+  /**
+   * Convert from Future (lifted into IO eagerly via `now`, or delayed via `point`)
+   * to `IO` for some desired error type `E`
+   */
+  final def fromFuture[E, A](io: IO[Void, Future[A]])(implicit ec: ExecutionContext): IO[Throwable, A] =
+    io.attempt[Throwable].flatMap { f =>
+      IO.async { cb =>
+        f.map(
+          _.onComplete(
+            t =>
+              cb(
+                t.fold(ExitResult.Failed.apply, ExitResult.Completed.apply)
+            )
+          )
+        )
+      }
+    }
 
   // TODO: Make this fast, generalize from `Unit` to `A: Semigroup`,
   // and use `IList` instead of `List`.

--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -10,7 +10,6 @@ import scalaz.ioeffect.Errors.TerminatedException
 import scalaz.Liskov.<~<
 
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.{ Failure, Success }
 
 /**
  * An `IO[E, A]` ("Eye-Oh of Eeh Aye") is an immutable data structure that

--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -784,11 +784,15 @@ object IO extends IOInstances {
   final def fromFuture[E, A](io: IO[Void, Future[A]])(implicit ec: ExecutionContext): IO[Throwable, A] =
     io.attempt[Throwable].flatMap { f =>
       IO.async { cb =>
-        f.map(
+        f.fold(
+          _.absurd[Unit],
           _.onComplete(
             t =>
               cb(
-                t.fold(ExitResult.Failed.apply, ExitResult.Completed.apply)
+                t.fold(
+                  ExitResult.Failed.apply,
+                  ExitResult.Completed.apply
+                )
             )
           )
         )

--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -10,6 +10,7 @@ import scalaz.ioeffect.Errors.TerminatedException
 import scalaz.Liskov.<~<
 
 import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
 
 /**
  * An `IO[E, A]` ("Eye-Oh of Eeh Aye") is an immutable data structure that
@@ -787,12 +788,10 @@ object IO extends IOInstances {
           _.absurd[Unit],
           _.onComplete(
             t =>
-              cb(
-                t.fold(
-                  ExitResult.Failed.apply,
-                  ExitResult.Completed.apply
-                )
-            )
+              cb(t match {
+                case Success(a) => ExitResult.Completed(a)
+                case Failure(t) => ExitResult.Failed(t)
+              })
           )
         )
       }

--- a/ioeffect/src/main/scala/scalaz/ioeffect/IOInstances.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IOInstances.scala
@@ -9,4 +9,5 @@ trait IOInstances {
     override def bind[A, B](fa: IO[E, A])(f: A => IO[E, B]): IO[E, B] =
       fa.flatMap(f)
   }
+
 }

--- a/ioeffect/src/main/scala/scalaz/ioeffect/MonadIO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/MonadIO.scala
@@ -1,0 +1,22 @@
+package scalaz.ioeffect
+
+import scalaz.Monad
+
+/***
+ * Monads in which `IO` computations may be embedded. Any monad built by applying a sequence of
+ * monad transformers to the `IO` monad will be an instance of this class. Instances should satisfy the following laws,
+ * which state that `liftIO` is a transformer of monads:
+ *
+ * liftIO . return = return
+ * liftIO (m >>= f) = liftIO m >>= (liftIO . f)
+ *
+ * @tparam M - the monad in which to lift
+ */
+trait MonadIO[M[_]] extends Monad[M] {
+
+  /**
+   * Lift a computation from the `IO` monad into `M`
+   */
+  def liftIO[E, A](io: IO[E, A]): M[A]
+
+}

--- a/ioeffect/src/main/scala/scalaz/ioeffect/RTS.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/RTS.scala
@@ -49,13 +49,11 @@ trait RTS {
    */
   final def accursedConversionToFuture[E, A](io: IO[E, A]): concurrent.Future[E \/ A] = {
     val p = concurrent.Promise[E \/ A] // we must store the information associated with E in \/
-    unsafePerformIOAsync(io.attempt[Throwable])(
-      _ match {
-        case ExitResult.Completed(a)  => p.success(a)
-        case ExitResult.Failed(e)     => p.failure(e)
-        case ExitResult.Terminated(t) => p.failure(t)
-      }
-    )
+    unsafePerformIOAsync(io.attempt[Throwable])({
+      case ExitResult.Completed(a)  => p.success(a)
+      case ExitResult.Failed(e)     => p.failure(e)
+      case ExitResult.Terminated(t) => p.failure(t)
+    })
     p.future
   }
 

--- a/ioeffect/src/main/scala/scalaz/ioeffect/RTS.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/RTS.scala
@@ -4,12 +4,13 @@ package scalaz.ioeffect
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.{ Executors, TimeUnit }
 
-import scalaz.{ -\/, \/- }
+import scalaz.{ -\/, \/, \/- }
 
 import scala.annotation.{ switch, tailrec }
 import scala.concurrent.duration.Duration
 import java.util.concurrent.{ ExecutorService, ScheduledExecutorService }
-import scalaz.ioeffect.RTS.FiberStatus.Executing
+
+import scala.concurrent
 
 /**
  * This trait provides a high-performance implementation of a runtime system for
@@ -40,6 +41,22 @@ trait RTS {
       case Async.Now(v) => k(v)
       case _            =>
     }
+  }
+
+  /**
+   * WARNING: UNSAFE - convert between IO[?, A] and Future - do not use this method.
+   * Seriously, try not to.
+   */
+  final def accursedConversionToFuture[E, A](io: IO[E, A]): concurrent.Future[E \/ A] = {
+    val p = concurrent.Promise[E \/ A] // we must store the information associated with E in \/
+    unsafePerformIOAsync(io.attempt[Throwable])(
+      _ match {
+        case ExitResult.Completed(a)  => p.success(a)
+        case ExitResult.Failed(e)     => p.failure(e)
+        case ExitResult.Terminated(t) => p.failure(t)
+      }
+    )
+    p.future
   }
 
   /**

--- a/ioeffect/src/test/scala/scalaz/ioeffect/IOTest.scala
+++ b/ioeffect/src/test/scala/scalaz/ioeffect/IOTest.scala
@@ -1,0 +1,47 @@
+package scalaz.ioeffect
+
+import org.specs2.concurrent.ExecutionEnv
+import org.specs2.Specification
+import org.specs2.specification.AroundTimeout
+import org.specs2.matcher.MatchResult
+import org.specs2.specification.core.SpecStructure
+import scalaz._
+import Scalaz._
+
+import scala.concurrent.Future
+
+class IOTest(implicit ee: ExecutionEnv) extends Specification with AroundTimeout with RTS {
+
+  override def defaultHandler[E]: Throwable => IO[E, Unit] = _ => IO.unit[E]
+
+  def is: SpecStructure =
+    s2"""
+    IO `fromFuture` values with `IO.now`
+      values should respect Future.successful $fromFutureSpecIONowSuccessful
+      values should respect Future.apply $fromFutureSpecIONowApply
+
+    IO `fromFuture` values with `IO.point`
+      values should respect Future.successful $fromFutureSpecIONowSuccessful
+      values should respect Future.apply $fromFutureSpecIONowApply
+      """
+
+  def fromFutureSpecIONowSuccessful: MatchResult[Int] =
+    unsafePerformIO(IO.fromFuture(IO.now(Future.successful(1)))) must_===
+      unsafePerformIO(IO.now[Throwable, Int](1))
+
+  def fromFutureSpecIONowApply: MatchResult[Int] =
+    unsafePerformIO(IO.fromFuture(IO.now(Future(1)))) must_===
+      unsafePerformIO(IO.now[Throwable, Int](1))
+
+  def fromFutureSpecIOPointSuccessful: MatchResult[Int] =
+    unsafePerformIO(IO.fromFuture(IO.point(Future.successful(1)))) must_===
+      unsafePerformIO(IO.now[Throwable, Int](1))
+
+  def fromFutureSpecIOPointApply: MatchResult[Int] =
+    unsafePerformIO(IO.fromFuture(IO.point(Future(1)))) must_===
+      unsafePerformIO(IO.now[Throwable, Int](1))
+
+  def accursedConversionsSpec: MatchResult[Future[Throwable \/ Int]] =
+    accursedConversionToFuture(IO.now[Throwable, Int](1)).must_===(Future.successful(1.right[Throwable]))
+
+}

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -77,7 +77,8 @@ object ProjectPlugin extends AutoPlugin {
         "-Ypartial-unification",
         "-Xlog-free-terms",
         "-Xlog-free-types",
-        "-Xlog-reflective-calls"
+        "-Xlog-reflective-calls",
+        "-language:higherKinds"
       ),
       scalacOptions ++= extraScalacOptions(scalaVersion.value),
       // WORKAROUND https://github.com/ghik/silencer/issues/7


### PR DESCRIPTION
This PR addresses [issue 44](https://github.com/scalaz/ioeffect/issues/44). Additionally, I found we were missing the associated `IO e a -> Future a` conversion, and added that too, with some minimal tests. The name is only kind of a joke - we need to come up with a name that's offensive enough to use in production that you should feel shame for it.

 I've also added `MonadIO`, which is sorely missing, as well as `IO#fold`, because why not.