### PR TITLE
Add LiftIO to IO 

### DIFF
--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -527,10 +527,10 @@ sealed abstract class IO[E, A] { self =>
     self.attempt[E2].map(_.fold(err, succ))
 
   /**
-    * For some monad F and some error type E, lift this IO
-    * into F if there is a monadIO instance for F
-    * 
-    */
+   * For some monad F and some error type E, lift this IO
+   * into F if there is a monadIO instance for F
+   *
+   */
   final def liftIO[F[_]](implicit M: Monad[F], MM: MonadIO[F, E]): F[A] =
     MM.liftIO(this)
 

--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -529,7 +529,6 @@ sealed abstract class IO[E, A] { self =>
   /**
    * For some monad F and some error type E, lift this IO
    * into F if there is a monadIO instance for F
-   *
    */
   final def liftIO[F[_]: Monad](implicit M: MonadIO[F, E]): F[A] = MM.liftIO(self)
 

--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -531,8 +531,7 @@ sealed abstract class IO[E, A] { self =>
    * into F if there is a monadIO instance for F
    *
    */
-  final def liftIO[F[_]](implicit M: Monad[F], MM: MonadIO[F, E]): F[A] =
-    MM.liftIO(this)
+  final def liftIO[F[_]: Monad](implicit M: MonadIO[F, E]): F[A] = MM.liftIO(self)
 
   /**
    * An integer that identifies the term in the `IO` sum type to which this

--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -530,7 +530,7 @@ sealed abstract class IO[E, A] { self =>
    * For some monad F and some error type E, lift this IO
    * into F if there is a monadIO instance for F
    */
-  final def liftIO[F[_]: Monad](implicit M: MonadIO[F, E]): F[A] = MM.liftIO(self)
+  final def liftIO[F[_]: Monad](implicit M: MonadIO[F, E]): F[A] = M.liftIO(self)
 
   /**
    * An integer that identifies the term in the `IO` sum type to which this

--- a/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/IO.scala
@@ -3,10 +3,9 @@ package scalaz.ioeffect
 
 import scala.annotation.switch
 import scala.concurrent.duration._
-import scalaz.{ -\/, @@, \/, \/-, unused, Maybe }
+import scalaz.{ -\/, @@, \/, \/-, unused, Maybe, Monad }
 import scalaz.syntax.either._
 import scalaz.ioeffect.Errors._
-import scalaz.ioeffect.Errors.TerminatedException
 import scalaz.Liskov.<~<
 import scalaz.Tags.Parallel
 
@@ -526,6 +525,14 @@ sealed abstract class IO[E, A] { self =>
    */
   final def fold[E2, B](err: E => B, succ: A => B): IO[E2, B] =
     self.attempt[E2].map(_.fold(err, succ))
+
+  /**
+    * For some monad F and some error type E, lift this IO
+    * into F if there is a monadIO instance for F
+    * 
+    */
+  final def liftIO[F[_]](implicit M: Monad[F], MM: MonadIO[F, E]): F[A] =
+    MM.liftIO(this)
 
   /**
    * An integer that identifies the term in the `IO` sum type to which this

--- a/ioeffect/src/main/scala/scalaz/ioeffect/MonadIOInstances.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/MonadIOInstances.scala
@@ -4,7 +4,7 @@ package ioeffect
 import scalaz._
 import Scalaz._
 
-abstract class MonadIOInstances extends MonadIOInstances1 {
+sealed abstract class MonadIOInstances extends MonadIOInstances1 {
 
   implicit val taskMonadIO: MonadIO[Task, Throwable] = new MonadIO[Task, Throwable] {
     override def liftIO[A](io: IO[Throwable, A])(implicit M: Monad[Task]): Task[A] = io

--- a/ioeffect/src/main/scala/scalaz/ioeffect/MonadIOInstances.scala
+++ b/ioeffect/src/main/scala/scalaz/ioeffect/MonadIOInstances.scala
@@ -1,9 +1,10 @@
-package scalaz.ioeffect
+package scalaz
+package ioeffect
 
 import scalaz._
 import Scalaz._
 
-sealed abstract class MonadIOInstances extends MonadIOInstances1 {
+abstract class MonadIOInstances extends MonadIOInstances1 {
 
   implicit val taskMonadIO: MonadIO[Task, Throwable] = new MonadIO[Task, Throwable] {
     override def liftIO[A](io: IO[Throwable, A])(implicit M: Monad[Task]): Task[A] = io


### PR DESCRIPTION
en lieu of syntax (io is the only affected type), here's a pr adding `liftIO` to `IO`